### PR TITLE
Resolve #6: Added Sonar properties to evaluate Thymeleaf templates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <sonar.projectKey>codepenguin-org_spring-boot-openfeign-restcountries-example</sonar.projectKey>
         <sonar.organization>codepenguin-org</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.sources>src/main/java,src/main/resources/templates</sonar.sources>
         <spring-cloud.version>2020.0.2</spring-cloud.version>
     </properties>
     <dependencies>


### PR DESCRIPTION
- Added the following property to `pom.xml` to evaluate Thymelead templates and solve that warning:
`<sonar.sources>src/main/java,src/main/resources/templates</sonar.sources>`